### PR TITLE
FADCのpeak-to-peakを検出して, 平均を取って出力する

### DIFF
--- a/mada_reader/files.py
+++ b/mada_reader/files.py
@@ -1,5 +1,6 @@
-from typing import List
 from pathlib import Path
+from typing import List
+
 from mada_reader.models.mada_config import MadaConfig, get_mada_config
 
 

--- a/mada_reader/files.py
+++ b/mada_reader/files.py
@@ -1,6 +1,6 @@
 from typing import List
 from pathlib import Path
-from mada_reader.models.mada_config import MadaConfig
+from mada_reader.models.mada_config import MadaConfig, get_mada_config
 
 
 def scan_mada_files(
@@ -27,3 +27,17 @@ def scan_mada_files(
     target_mada_files.sort(key=lambda x: x.name[8:12])
 
     return target_mada_files
+
+
+def scan_mada_files_from_path(
+    dir: Path,
+    mada_config_path: Path,
+    initial_period: int = 0,
+    final_period: int = 0
+) -> List[Path]:
+    return scan_mada_files(
+        dir,
+        get_mada_config(mada_config_path),
+        initial_period,
+        final_period,
+    )

--- a/mada_reader/models/mada_config.py
+++ b/mada_reader/models/mada_config.py
@@ -1,6 +1,7 @@
 import json
-from typing import Literal, List
 from pathlib import Path
+from typing import List, Literal
+
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 

--- a/mada_reader/models/mada_config.py
+++ b/mada_reader/models/mada_config.py
@@ -89,3 +89,8 @@ def parse(json_string: str) -> MadaConfig:
         ))
 
     return MadaConfig(giga_iwaki_list, adalm_list)
+
+
+def get_mada_config(mada_config_path: Path) -> MadaConfig:
+    with open(mada_config_path, "r") as f:
+        return parse(f.read())

--- a/mada_reader/parser.py
+++ b/mada_reader/parser.py
@@ -1,8 +1,9 @@
-from typing import List, Tuple, Optional
-from dataclasses import dataclass, field
-from pathlib import Path
 import struct
 import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
 import bitstruct
 
 

--- a/mada_reader/pyroot_lib/util.py
+++ b/mada_reader/pyroot_lib/util.py
@@ -1,4 +1,5 @@
 from array import array
+
 import ROOT as r
 
 

--- a/mada_reader/rootfile_generator/gbkb.py
+++ b/mada_reader/rootfile_generator/gbkb.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import List
+from typing import List, Optional
+from nptyping import NDArray, Shape, Float
 from copy import copy
 
 import ROOT as r
 import numpy as np
-import mada_reader.models.mada_config as config
 from mada_reader.pyroot_lib.util import pyroot_func
-from mada_reader.parser import Event, parse_from_mada_file
+from mada_reader.parser import Event, parse_from_mada_file, FlushADC
 
 
 def draw_waveform_hist2d(events: List[Event]) -> List[r.TH2D]:
@@ -58,3 +58,29 @@ def mada_to_root(target_mada_path: Path) -> None:
     hists = draw_waveform_hist2d(events)
     for h in hists:
         h.Write()
+
+
+def calc_fadc_peak2peak(fadc: FlushADC) -> Optional[List[float]]:
+    """
+    1イベントのFADCのp2pを4chぶん取得する
+    [shape (4,)]
+    """
+    ret = [0., 0., 0., 0.]
+    for i, fadc_ch_i in enumerate(fadc):
+        if fadc_ch_i:
+            ret[i] = float(abs(max(fadc_ch_i) - min(fadc_ch_i)))
+        else:
+            return None
+    return ret
+
+
+def get_fadc_peak2peak_from_mada_file(target_mada_path: Path) -> NDArray:
+    """
+    .mada 1ファイル分の p2p を np.array で取得する 
+    [shape (n_events, 4)]
+    """
+    events = parse_from_mada_file(target_mada_path)
+    fadc_list = list(map(lambda e: e.fadc, events))
+    ret = list(map(calc_fadc_peak2peak, fadc_list))
+    ret = filter(lambda x: x != None, ret)
+    return np.array(list(ret))

--- a/mada_reader/rootfile_generator/gbkb.py
+++ b/mada_reader/rootfile_generator/gbkb.py
@@ -1,12 +1,13 @@
+from copy import copy
 from pathlib import Path
 from typing import List, Optional
-from nptyping import NDArray, Shape, Float
-from copy import copy
 
-import ROOT as r
 import numpy as np
+import ROOT as r
+from nptyping import NDArray
+
+from mada_reader.parser import Event, FlushADC, parse_from_mada_file
 from mada_reader.pyroot_lib.util import pyroot_func
-from mada_reader.parser import Event, parse_from_mada_file, FlushADC
 
 
 def draw_waveform_hist2d(events: List[Event]) -> List[r.TH2D]:
@@ -82,5 +83,5 @@ def get_fadc_peak2peak_from_mada_file(target_mada_path: Path) -> NDArray:
     events = parse_from_mada_file(target_mada_path)
     fadc_list = list(map(lambda e: e.fadc, events))
     ret = list(map(calc_fadc_peak2peak, fadc_list))
-    ret = filter(lambda x: x != None, ret)
-    return np.array(list(ret))
+    ret = list(filter(lambda x: x != None, ret))
+    return np.array(ret)

--- a/mada_reader/vis.py
+++ b/mada_reader/vis.py
@@ -1,6 +1,7 @@
 import ROOT as r
-from mada_reader.pyroot_lib import util
+
 from mada_reader.parser import FlushADC
+from mada_reader.pyroot_lib import util
 
 
 @util.pyroot_func

--- a/poetry.lock
+++ b/poetry.lock
@@ -319,6 +319,25 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "nptyping"
+version = "2.4.0"
+description = "Type hints for NumPy."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+numpy = {version = ">=1.20.0,<2.0.0", markers = "python_version >= \"3.8\""}
+typing-extensions = {version = ">=4.0.0,<5.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+build = ["invoke (>=1.6.0)", "pip-tools (>=6.5.0)"]
+complete = ["pandas", "pandas-stubs-fork"]
+dev = ["invoke (>=1.6.0)", "pip-tools (>=6.5.0)", "autoflake", "black", "coverage", "codecov (>=2.1.0)", "feedparser", "isort", "mypy", "pylint", "pyright", "setuptools", "typeguard", "wheel", "pandas", "beartype (<0.10.0)", "beartype (>=0.10.0)", "pandas-stubs-fork"]
+pandas = ["pandas", "pandas-stubs-fork"]
+qa = ["autoflake", "black", "coverage", "codecov (>=2.1.0)", "feedparser", "isort", "mypy", "pylint", "pyright", "setuptools", "typeguard", "wheel", "beartype (<0.10.0)", "beartype (>=0.10.0)"]
+
+[[package]]
 name = "numpy"
 version = "1.23.4"
 description = "NumPy is the fundamental package for array computing with Python."
@@ -699,7 +718,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c721a50675dd6694da942406bb3dbc1d4decfd1afb5e5d56602cd1cffd52a4ae"
+content-hash = "becbec6811e4bd26d9fa857412574ed703d0cc656467d98c8d98eb344808c29a"
 
 [metadata.files]
 argcomplete = []
@@ -729,6 +748,7 @@ markupsafe = []
 mccabe = []
 more-itertools = []
 mypy-extensions = []
+nptyping = []
 numpy = []
 openapi-schema-validator = []
 openapi-spec-validator = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -718,7 +718,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "becbec6811e4bd26d9fa857412574ed703d0cc656467d98c8d98eb344808c29a"
+content-hash = "8efcd68864b01f08842f24be2da5f11f3d2657a34b2ef9b25aa5ad7436b7a42f"
 
 [metadata.files]
 argcomplete = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ pytest = "^5.2"
 autopep8 = "^1.7.0"
 flake8 = "^5.0.4"
 datamodel-code-generator = "^0.13.5"
+nptyping = "^2.4.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ autopep8 = "^1.7.0"
 flake8 = "^5.0.4"
 datamodel-code-generator = "^0.13.5"
 nptyping = "^2.4.0"
+isort = "^5.10.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/models/test_mada_config.py
+++ b/tests/models/test_mada_config.py
@@ -1,4 +1,4 @@
-from mada_reader.models.mada_config import Connection, GigaIwaki, Adalm, parse
+from mada_reader.models.mada_config import Adalm, Connection, GigaIwaki, parse
 
 JSON_STRING = """
     {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,3 @@
-from mada_reader import parser, cli
+from mada_reader import cli, parser
 
 MADAFILE = "tests/assets/GBKB-13_0004.mada"

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from mada_reader.files import scan_mada_files
 from mada_reader.models.mada_config import parse
 


### PR DESCRIPTION
## 概要
- テストパルスの応答からgainを計算するのに使う
- `perXXXX`内のファイルをスキャンしてボード,chごとにpeak-to-peakを検出してその平均値を出力する