### PR TITLE
FADCの波形から正負のピークを表示させる

### DIFF
--- a/mada_reader/parser.py
+++ b/mada_reader/parser.py
@@ -82,7 +82,7 @@ def parse_flush_adc(
             event[0:event_reading_bytes]
         )
     except bitstruct.Error as e:
-        print(e, sys.stderr)
+        print(e, file=sys.stderr)
         return None
 
     for i_iter in range(0, len(fadc_unpacked), 3):


### PR DESCRIPTION
## 概要
- ゲイン測定のため

## 詳細
- 1イベントごとにベースラインを計算
- 矩形のテストパルスを仮定してベースラインからのプラマイの波高を計算する
- 指定したファイルたちの間で波高を平均する
- 結果をcsvっぽくprint
- リダイレクトとか使ってファイルに書き出して使うコマンド